### PR TITLE
Markdown cleanup

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,5 +1,5 @@
 
-##Contents
+## Contents
 
 [Overview](#overview)  
 [Requirement Documentation](#requirement-documentation)  
@@ -8,7 +8,7 @@
 [Design Sprint Mix](#design-sprint-mix)  
 [The How and When of Sprint Planning](#the-how-and-when-of-sprint-planning)  
 
-##Overview 
+## Overview 
 
 On our Agile team, the product owner’s core responsibilities are to:
 - Define and document feature requirements
@@ -19,7 +19,7 @@ On our Agile team, the product owner’s core responsibilities are to:
 
 Every product owner does things a little different. Here’s how our team’s product owners tackle documentation and sprint planning.
 
-##Requirement Documentation
+## Requirement Documentation
 
 Requirement documentation is the first stage in the process of building a feature - loosely defined as a new piece of functionality, whether it be user-facing, or something like new analytics. Before design or development can start building something, the team must have a shared understanding of the problems we’re trying to solve and why we want to solve them. Those questions are answered via a detailed document that should:
 
@@ -30,11 +30,11 @@ Requirement documentation is the first stage in the process of building a featur
 
 While not necessary, this document might also include high-level user experience recommendations, user flow sketches, market research, and product data.
 
-##Sprint Planning
+## Sprint Planning
 
 The product owner is responsible for planning and prioritizing all tasks in a sprint. We run distinct sprints for design and development teams, as each has their own cadence of how work is done. 
 
-###Development Sprint Mix
+### Development Sprint Mix
 
 Development sprints should be a mix of 5 distinct types of tasks: Features, bugs, technical debt, research, and QA. Each task type has it's own backlog in a project tracker tool (such as JIRA, Pivotal, or Zenhub). Every sprint should contain at least a few points worth of each task type, to ensure no single task type receives disproportionate attention. Committing to servicing all of these task types ensures we maintain product stability while still continuing to ship new and exciting features in the most efficient way possible. 
 
@@ -50,7 +50,7 @@ When allocating developer time, we generally try to create a sprint mix consisti
 
 When the sprint mix is finalized and the tasks have been assigned, the product owner is responsible for prioritizing each engineer’s task queue. There should never be a question of ‘what do I do next?’. The answer should be dictated by the priority in the task queue.
 
-###Design Sprint Mix
+### Design Sprint Mix
 
 Designing a feature generally consists of 5 unique task types: Feature discovery, wireframing/prototyping, production design, reviews, and documentation. These tasks should be performed in this specific order, and can oftentimes span multiple sprints. We allocate time for each of these task types to ensure that no part of the design process is unaccounted for, so designers have plenty of time to review requirements and document their work before handing it off to developers. These tickets are created and prioritized by the product owner.
 
@@ -65,7 +65,7 @@ For some design tasks, not every step in this cadence is required. For instance,
 
 There are no guidelines for how long each of these tasks should take. Sometimes Feature Discovery could span an entire sprint, if in-depth user research is required. Alternatively, the entire cadence of tasks could happen in a matter of days if the design estimates the work to take that long.
 
-###The How and When of Sprint Planning
+### The How and When of Sprint Planning
 
 A sprint should be fully ticketed and prioritized prior to your ‘Sprint Planning Day’, when the task assignment, planning poker and commitment meetings occur. Ideally, sprints are ticketed and prioritized far in advance of that day, so developers and designers have a chance to review tickets and provide feedback.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 aka **How We Collaborate** :zap:
 
-##Contents
+## Contents
 
 [Overview](#overview)  
 [Why Process?](#why-process)  
@@ -14,18 +14,18 @@ aka **How We Collaborate** :zap:
 [Notes](#notes)  
 [Contributors](#contributors)  
 
-##Overview
+## Overview
 
 This document is an overview of the [Vimeo Mobile and TV Group's](#notes)<sup>1</sup> product development process (a process based on [scrum](https://en.wikipedia.org/wiki/Scrum_(software_development)) and [agile](https://en.wikipedia.org/wiki/Agile_software_development) methodologies). It describes [why process](#why-process) is important and outlines five aspects of our process: [team](#team), [workflow](#workflow), [sprints](#sprints), [velocity tracking](#velocity-tracking) and the [exchange program](#exchange-program). This document focuses on high-level guidelines rather than specific implementation tactics in order to leave room for teams to apply them as they see fit. 
 
-##Why Process?
+## Why Process?
 
 Process helps us to:
  
 1. Produce high quality work at a predictable [pace](#notes)<sup>2</sup>, 
 2. Promote the development of an extraordinary team.
  
-##Team
+## Team
  
 A product team is a co-located, cross-functional group of roughly 4-7 people who collaborate to bring ideas to life. Proximity builds relationships. Cross-functionality fosters autonomy and self-sufficiency. Limiting team size promotes ownership.
  
@@ -34,7 +34,7 @@ A product team is a co-located, cross-functional group of roughly 4-7 people who
 
 Teams are externally trusted, transparent, and accountable. Teams are internally creative, balanced, and practical. Teams typically include a product manager, designer(s), engineer(s), and a QA representative. Read more about the product manager's core responsibilities [here](/PRODUCT.md).
 
-##Workflow
+## Workflow
  
 Workflow is a structured approach to how a team evolves an idea from inception to production. Teams evolve each idea one function at a time, with each function’s output being the next function’s input. 
 
@@ -51,7 +51,7 @@ These checks and balances help us define problems more accurately. This makes us
 
 We solicit feedback early, ask questions often, and [document and share what we learn](#notes)<sup>3</sup> along the way. 
 
-##Sprints
+## Sprints
  
 Sprints are structured 2-week intervals at which a team executes the above workflow to evolve ideas. Sprints help teams establish [pace](#notes)<sup>2</sup>. Pace is valuable because it allows us to predict how long projects will take in the short and long term. 
  
@@ -75,7 +75,7 @@ After finishing a sprint we hold a retrospective to discuss what went well, what
 
 The following sections provide more detail on specific phases of sprint planning mentioned above. 
 
-##Task Estimation 
+## Task Estimation 
 
 Each task requires an estimated point value based on time, complexity, and unknowns. Ensuring tickets are broken down into sensible, actionable chunks can reduce unknowns and allow the team to point a ticket based on the task’s time and complexity. A good scale to use for point values is the fibonacci sequence (1, 2, 3, 5, 8, 13) [because it reflects that uncertainty on how to execute a task increases with task size](http://www.scrum-institute.org/Effort_Estimations_Planning_Poker.php).
 
@@ -158,20 +158,20 @@ Task estimation is a difficult process but it naturally improves across sprints 
 
 Velocity tracking helps keep workloads at a reasonable amount. After tracking velocity for a few sprints a team should see a considerable improvement in comfort (i.e. committing to just the right amount of work), predictability, and consistency.
 
-##Exchange Program
+## Exchange Program
 
 In order to promote personal growth and inter-team knowledge transfer we offer an engineering exchange program. An exchange is a single or multi-sprint-long period where an engineer from another group can contribute to one of our projects in a structured way. This is an opportunity for exchange participants to learn new platforms, languages, and team processes.
 
 When someone participates in an exchange they are paired up with a member of the team that's working on the project that they'll be contributing to. This point-person helps them get set up and provides guidance and mentorship during the exchange. Exchange participants attend all sprint planning meetings, daily scrum, and sprint retrospective.
 
-##Notes
+## Notes
 
 1. At the time of writing, the Vimeo Mobile & TV Group is comprised of roughly 20 people. 
 2. To track velocity, we use [Pace-iOS](https://github.com/vimeo/Pace-iOS) and [Pace-Android](https://github.com/vimeo/Pace-Android) (both coming soon).
 3. We use Confluence for most documentation, but any wiki-like tool will do.
 4. We use Jira for task management, but tools like Trello, Zenhub, or a simple whiteboard or post-it note wall will work.
 
-##Contributors
+## Contributors
 
 Ryan Casey    
 Brian Cooper   


### PR DESCRIPTION
Github recently changed the syntax for headers in markdown files, and this broke a lot of headers. This PR fixes the headers.